### PR TITLE
Allow lazy loading extensions

### DIFF
--- a/lib/ace/rails/engine.rb
+++ b/lib/ace/rails/engine.rb
@@ -2,9 +2,8 @@ module Ace
   module Rails
     class Engine < ::Rails::Engine
       initializer 'ace-rails-ap.assets.precompile' do |app|
-        app.config.assets.precompile += %w[ace/worker-*.js ace/mode-*.js]
+        app.config.assets.precompile += %w[ace/worker-*.js ace/mode-*.js ace/ext-*.js]
       end
     end
   end
 end
-

--- a/vendor/assets/javascripts/set_ace_paths.js.erb
+++ b/vendor/assets/javascripts/set_ace_paths.js.erb
@@ -7,3 +7,7 @@ ace.config.setModuleUrl("ace/mode/<%= worker %>_worker", "<%= asset_path "ace/wo
 <% mode = File.basename(file, '.js').sub(/^mode-/, '') %>
 ace.config.setModuleUrl("ace/mode/<%= mode %>", "<%= asset_path "ace/mode-#{mode}.js" %>");
 <% end %>
+<% Dir[File.dirname(__FILE__) + '/ace/ext-*.js'].sort.each do |file| %>
+<% ext = File.basename(file, '.js').sub(/^ext-/, '') %>
+ace.config.setModuleUrl("ace/<%= ext %>", "<%= asset_path "ace/ext-#{ext}.js" %>");
+<% end %>


### PR DESCRIPTION
This should fix the search extension. With the following error:

```
Failed to load resource: the server responded with a status of 404 (Not Found) on /assets/ace/ext-searchbox.js
```

In order to make it work the search module should be loaded with the
proper asset_path reference, just like the workers and modes.